### PR TITLE
Fix & improve lf's moveto, copyto and cd to bm-dir (#994)

### DIFF
--- a/.config/lf/lfrc
+++ b/.config/lf/lfrc
@@ -52,7 +52,7 @@ cmd moveto ${{
 	clear; tput cup $(($(tput lines)/3)); tput bold
 	set -f
 	clear; echo "Move to where?"
-	dest="$(cut -d'	' -f2- ${XDG_CONFIG_HOME:-$HOME/.config}/shell/bm-dirs | fzf | sed 's|~|$HOME|' )" &&
+	dest="$(awk '{ gsub(/#.*/, ""); } !/^$/ { print $2 }' ${XDG_CONFIG_HOME:-$HOME/.config}/shell/bm-dirs | fzf)" &&
 	for x in $fx; do
 		eval mv -iv \"$x\" \"$dest\"
 	done &&
@@ -63,7 +63,7 @@ cmd copyto ${{
 	clear; tput cup $(($(tput lines)/3)); tput bold
 	set -f
 	clear; echo "Copy to where?"
-	dest="$(cut -d'	' -f2- ${XDG_CONFIG_HOME:-$HOME/.config}/shell/bm-dirs | fzf | sed 's|~|$HOME|' )" &&
+	dest="$(awk '{ gsub(/#.*/, ""); } !/^$/ { print $2 }' ${XDG_CONFIG_HOME:-$HOME/.config}/shell/bm-dirs | fzf)" &&
 	for x in $fx; do
 		eval cp -ivr \"$x\" \"$dest\"
 	done &&
@@ -75,7 +75,7 @@ cmd bulkrename $vidir
 
 # Bindings
 map <c-f> $lf -remote "send $id select '$(fzf)'"
-map J $lf -remote "send $id cd $(cut -d'	' -f2 ${XDG_CONFIG_HOME:-$HOME/.config}/shell/bm-dirs | fzf)"
+map J $lf -remote "send $id cd $(awk '{ gsub(/#.*/, ""); } !/^$/ { print $2 }' ${XDG_CONFIG_HOME:-$HOME/.config}/shell/bm-dirs | fzf | sed "s/\${.*-// ; s/}//" | envsubst)"
 map gh
 map g top
 map D delete


### PR DESCRIPTION
* Changed paru to yay due to new LARBS changes

* Fix & improve lf's moveto, copyto and cd to bm-dir

When using any of the above functions they returned exit code 1. This was due to the cut command having tab as the delimiter, but spaces are used in the bm-dirs file. 
As an improvement comments are now automatically removed from the fzf options, because selecting those wouldn't work anyway.
The final sed command substituting "~" for "$HOME" is also removed because that doesn't seem to do anything looking at the current structure of the bm-dirs file.
The J bind needed more parsing and environment variable substitution because cd didn't work by default with values from a subshell.